### PR TITLE
Rename integration-tests references

### DIFF
--- a/scripts/ci/integration-test.travis.sh
+++ b/scripts/ci/integration-test.travis.sh
@@ -33,8 +33,8 @@ fetch(){
 	git clone https://github.com/hpi-schul-cloud/docker-compose.git docker-compose
 	switchBranch "docker-compose"
 
-	git clone https://github.com/hpi-schul-cloud/integration-tests.git integration-tests
-	switchBranch "integration-tests"
+	git clone https://github.com/hpi-schul-cloud/end-to-end-tests.git end-to-end-tests
+	switchBranch "end-to-end-tests"
 
 	git clone https://github.com/hpi-schul-cloud/node-notification-service.git node-notification-service
 	switchBranch "node-notification-service"
@@ -47,7 +47,7 @@ install(){
 	cd ..
 
 	cd schulcloud-server && npm ci && cd ..
-	cd integration-tests && npm ci && cd ..
+	cd end-to-end-tests && npm ci && cd ..
 }
 
 before(){
@@ -60,7 +60,7 @@ before(){
 }
 
 main(){
-	cd integration-tests
+	cd end-to-end-tests
 	npm run test
 	cd ..
 }


### PR DESCRIPTION
Should fix errors while spinning up the notification service during end-to-end-tests on Travis, like here: https://travis-ci.com/github/hpi-schul-cloud/schulcloud-server/jobs/426879819#L2515