### PR TITLE
added new scenario for deletion concept

### DIFF
--- a/features/management_students/deleteStudent.feature
+++ b/features/management_students/deleteStudent.feature
@@ -5,7 +5,7 @@ Feature: Set of tests to delete students
     Background: User opens Schul-cloud homepage Website
         Given user arrives on the Schul-Cloud homepage
 
-    @deletedStudentCanNotLogin
+    @deletedStudentCanNotLogin @deletionConcept
     Scenario Outline: As an admin, I want to be able to delete the user
         Given <userRole> logs in with email '<adminUsername>' and password '<adminPassword>'
         And <userRole> login is successful

--- a/features/management_students/deleteStudent.feature
+++ b/features/management_students/deleteStudent.feature
@@ -22,8 +22,7 @@ Feature: Set of tests to delete students
             | userRole | adminUsername                | adminPassword  | studentUsername                  | studentPassword | deletedUserRole |
             | admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | amelia.strobl.qa@schul-cloud.org | Schulcloud1qa!  | student         |
 
-
-@deletedStudentIsNotVisibleInTeam
+	@deletedStudentIsNotVisibleInTeam @deletionConcept
 	Scenario Outline: As an admin, I want to be able to delete the user and he will be no longer listed in team members
 		Given <userRole> logs in with email '<adminUsername>' and password '<adminPassword>'
 		And <userRole> login is successful
@@ -45,7 +44,26 @@ Feature: Set of tests to delete students
 			| userRole  | adminUsername                | adminPassword  | studentUserName 				  | firstName | lastName | teamName  | description      | color  | number |
 			| admin     | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | boris.wasser.qa@schul-cloud.org | Boris	  | Wasser   | test team | test description | orange | 2      |
 
-	@deletedStudentCanNotUseForgotPassword
+	@deletedStudentIsNotVisibleInCourse @deletionConcept
+	Scenario Outline: As an admin, I want to be able to delete the user and he will be no longer listed in course members
+		Given <userAdmin> logs in with email '<adminUsername>' and password '<password>'
+		And <userAdmin> login is successful
+		And <userAdmin> goes to management
+		And <userAdmin> goes to students management
+		When <userAdmin> clicks Edit-student with '<studentUserName>' button
+		And <userAdmin> clicks Delete-user button
+		And <userAdmin> clicks Delete-user button inside popup
+		And <userAdmin> logs out
+		And <userTeacher> logs in with email '<teacherUsername>' and password '<password>'
+		And <userTeacher> goes to courses page
+		Then <userTeacher> should see that course with name '<courseName>' is visible on the list
+		And <userTeacher> sees that course with name '<courseName>' contains number of members '<membersNumber>'
+
+		Examples:
+ 		| userAdmin | adminUsername				   | password		| studentUserName				  | firstName | lastName | userTeacher | teacherUsername				 | courseName					 | membersNumber |
+		| admin		| kai.admin.qa@schul-cloud.org | Schulcloud1qa! | boris.wasser.qa@schul-cloud.org | Boris	  | Wasser	 | teacher	   | karl.teacher.qa@schul-cloud.org | Course with subject and tasks | 1			 |
+
+	@deletedStudentCanNotUseForgotPassword @deletionConcept
 	Scenario Outline: As an admin, I want to be able to delete the user
 		Given <userRole> logs in with email '<adminUsername>' and password '<adminPassword>'
 		And <userRole> login is successful

--- a/features/management_teachers/deleteTeacher.feature
+++ b/features/management_teachers/deleteTeacher.feature
@@ -5,7 +5,7 @@ Feature: Set of tests to delete teachers
     Background: User opens Schul-cloud homepage Website
         Given user arrives on the Schul-Cloud homepage
 
-	@deletedTeacherCanNotLogin
+	@deletedTeacherCanNotLogin @deletionConcept
 	Scenario Outline: As an admin, I want to be able to delete the user
 		Given <userRole> logs in with email '<adminUsername>' and password '<adminPassword>'
 		And <userRole> login is successful
@@ -21,3 +21,30 @@ Feature: Set of tests to delete teachers
 		Examples:
 			| userRole | adminUsername                | adminPassword  | teacherUsername                 | teacherPassword | deletedUserRole |
 			| admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | lara.teacher.qa@schul-cloud.org | Schulcloud1qa!  | teacher         |
+
+	@deletedTeacherIsNotVisibleInCourse @deletionConcept
+	Scenario Outline: As an admin, I want to be able to delete the user and he will be no longer listed in course members
+		Given <userRole> logs in with email '<adminUsername>' and password '<adminPassword>'
+		And <userRole> login is successful
+		And <userRole> goes to management
+		And <userRole> goes to course management
+		And <userRole> clicks Edit-course with '<courseName>' button
+		And <userRole> adds another teacher with '<teacherName>' to course
+        When <userRole> clicks on Save-changes in course button
+		Then <userRole> should see that course with '<courseName>' has two teachers with names '<teacherNames>'
+		And <userRole> goes to teachers management
+		When <userRole> clicks Edit-teacher with '<teacherMailAddress>' button
+		And <userRole> clicks Delete-user button
+		And <userRole> clicks Delete-user button inside popup
+		Then <userRole> should see that user with email '<teacherMailAddress>' is not visible on the list
+		And <userRole> logs out
+		And <checkUserRole> logs in with email '<teacherUsername>' and password '<adminPassword>'
+		And <checkUserRole> login is successful
+		And <checkUserRole> goes to courses page
+        And <checkUserRole> sees that course with name '<courseName>' is visible on the list
+        When <checkUserRole> chooses course with name '<courseName>'
+        And <checkUserRole> clicks on Edit-course button
+		Then <checkUserRole> can not see deleted teacher with name '<teacherName>' on the list of teachers
+		Examples:
+			| userRole | adminUsername                | adminPassword  | courseName					   | teacherName | teacherNames	 | teacherMailAddress			   | checkUserRole | teacherUsername				 |
+			| admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | Course with subject and tasks | Lara Hande	 | Herzog, Hande | lara.teacher.qa@schul-cloud.org | teacher	   | karl.teacher.qa@schul-cloud.org |

--- a/page-objects/pages/coursePages/CRSSEditCopyCoursePage.js
+++ b/page-objects/pages/coursePages/CRSSEditCopyCoursePage.js
@@ -30,9 +30,14 @@ async function setNewCourseDescription(courseDescription) {
 	await waitHelpers.waitAndSetValue(courseDescriptionInput, courseDescription);
 }
 
-async function checkThatTeacherIsVisible(courseTeacher, expectedResult) {
+async function isTeacherVisible(courseTeacher, expectedResult) {
 	let teachersNames = await elementHelpers.getTextFromAllElements(courseTeacherInput);
-	expectedResult ? expect(teachersNames).to.include(courseTeacher) : expect(teachersNames).to.not.include(courseTeacher);
+	const msg = `Teacher with name ${courseTeacher} is not visible on the list \n`;
+	const resultMsg = `List of teachersNames: ${teachersNames}`;
+	expectedResult
+		? expect(teachersNames).to.include(courseTeacher)
+		: expect(teachersNames).to.not.include(courseTeacher);
+	return expect(teachersNames, msg + resultMsg).to.not.include(courseTeacher);
 }
 
 module.exports = {
@@ -41,5 +46,5 @@ module.exports = {
 	clickDeleteButton,
 	setNewCourseName,
 	setNewCourseDescription,
-	checkThatTeacherIsVisible,
+	isTeacherVisible,
 };

--- a/page-objects/pages/coursePages/CRSSEditCopyCoursePage.js
+++ b/page-objects/pages/coursePages/CRSSEditCopyCoursePage.js
@@ -8,6 +8,7 @@ const courseNameInput = 'form > div:nth-child(3) > input';
 const courseDescriptionInput = 'textarea';
 const deleteButton = 'a.btn-delete-course';
 const deleteButtonConfirmation = '.modal-content button.btn-submit';
+const courseTeacherInput = "select[name='teacherIds[]'] + div.chosen-container  span";
 
 async function clickSubmitButton() {
 	await elementHelpers.clickAndWait(submitBtn);
@@ -29,10 +30,16 @@ async function setNewCourseDescription(courseDescription) {
 	await waitHelpers.waitAndSetValue(courseDescriptionInput, courseDescription);
 }
 
+async function checkThatTeacherIsVisible(courseTeacher, expectedResult) {
+	let teachersNames = await elementHelpers.getTextFromAllElements(courseTeacherInput);
+	expectedResult ? expect(teachersNames).to.include(courseTeacher) : expect(teachersNames).to.not.include(courseTeacher);
+}
+
 module.exports = {
 	clickSubmitButton,
 	clickConfirmDeleteButton,
 	clickDeleteButton,
 	setNewCourseName,
 	setNewCourseDescription,
+	checkThatTeacherIsVisible,
 };

--- a/page-objects/pages/managementPages/ManageCoursesPage.js
+++ b/page-objects/pages/managementPages/ManageCoursesPage.js
@@ -1,1 +1,62 @@
-/*[url/administration/courses]*/
+/*[url/administration/courses]*/ /*[url/administration/courses]*/
+'use strict';
+
+const waitHelpers = require('../../../runtime/helpers/waitHelpers');
+const elementHelpers = require('../../../runtime/helpers/elementHelpers');
+
+const teacherSelect = '#teacherId_chosen';
+const courseNameContainer = "tbody[data-testid='students_names_container']";
+const tableOfCoursesRows = courseNameContainer + ' > tr';
+const courseNameCells = courseNameContainer + ' td:nth-child(1)';
+const teacherNamesCells = courseNameContainer + ' td:nth-child(3)';
+const editElements = courseNameContainer + ' i.fa-edit';
+
+async function setTeacher(teacherUsername) {
+	await elementHelpers.selectOptionByText(teacherSelect, teacherUsername);
+}
+
+async function clickEditCourseByNameBtn(courseName) {
+	await waitHelpers.waitUntilElementIsVisible(tableOfCoursesRows);
+	let coursesTable = await getCoursesDetailsList(courseNameCells);
+	let editsElements = await elementHelpers.getListOfAllElements(editElements);
+	for (let index = 0; index < coursesTable.length; index++) {
+		if (coursesTable[index] === courseName) {
+			await elementHelpers.clickAndWait(editsElements[index]);
+			break;
+		}
+	}
+}
+
+// choose between name, class(es), teachers
+async function getCoursesDetailsList(whichCell) {
+	let names = await elementHelpers.getTextFromAllElements(whichCell);
+	return names;
+}
+
+async function areTeacherNamesVisible(courseName, expectedTeacherNames) {
+	await waitHelpers.waitUntilElementIsVisible(tableOfCoursesRows);
+	let coursesNames = await getCoursesDetailsList(courseNameCells);
+	let teacherNames = await getCoursesDetailsList(teacherNamesCells);
+	let isTeacherNamesFound = false;
+	let courseMsg = `Course with name: ${courseName} not found.`;
+	let teacherNamesMsg = '';
+	for (let index = 0; index < coursesNames.length; index++) {
+		if (coursesNames[index] === courseName) {
+			courseMsg = `Course with name: ${courseName} has teacher names. \n`;
+			if (teacherNames[index] === expectedTeacherNames) {
+				isTeacherNamesFound = true;
+				teacherNamesMsg = 'TeacherNames '+expectedTeacherNames +' found';
+			}
+			else {
+				teacherNamesMsg = 'Expected: '+ expectedTeacherNames + ', Actual: '+ teacherNames[index];
+			}
+		}
+	}
+	expect(isTeacherNamesFound, courseMsg + teacherNamesMsg).to.equal(true);
+}
+
+module.exports = {
+	clickEditCourseByNameBtn,
+	setTeacher,
+	areTeacherNamesVisible,
+};

--- a/page-objects/pages/managementPages/ManageStudentsPage.js
+++ b/page-objects/pages/managementPages/ManageStudentsPage.js
@@ -115,12 +115,14 @@ async function isStudentEmailOnTheList(email) {
 	const resultMsg = `List of emails ${emails}`;
 	await expect(emails, msg + resultMsg).to.include(email);
 }
+
 async function isStudentFirstnameOnTheList(firstname) {
 	let firstnames = await getStudentsDetailsList(firstNameCell);
 	const msg = `Student with firstname ${firstname} is not visible on the students firstname list \n`;
 	const resultMsg = `List of firstnames ${firstnames}`;
 	await expect(firstnames, msg + resultMsg).to.include(firstname);
 }
+
 async function isStudentLastnameOnTheList(lastname) {
 	let lastnames = await getStudentsDetailsList(lastNameCell);
 	const msg = `Student with lastname ${lastname} is not visible on the student lastname list \n`;
@@ -145,6 +147,7 @@ async function submitConsent(e_mail) {
 		}
 	}
 }
+
 async function studentLogsInWithPasswordGenaratedByAdminDuringManualSubmission(userName) {
 	await loginPage.performLogin(userName, oldPassword);
 }

--- a/page-objects/pages/managementPages/ManageTeachersPage.js
+++ b/page-objects/pages/managementPages/ManageTeachersPage.js
@@ -9,8 +9,6 @@ const tableOfTeacherssColumn = 'tbody[data-testid="students_names_container"] > 
 const emailCell = '[data-testid="students_names_container"] td:nth-child(3)';
 const editElements = 'i.fa-edit';
 
-
-
 async function clickEditTeacherByMailBtn(userEmail) {
 	await waitHelpers.waitUntilElementIsVisible(tableOfTeacherssColumn);
 	let teachersTable = await getTeachersDetailsList(emailCell);

--- a/step_definitions/management_teachers/deleteTeacher_steps.js
+++ b/step_definitions/management_teachers/deleteTeacher_steps.js
@@ -23,5 +23,5 @@ Then(/^.* course with '([^']*)' has two teachers with names '([^']*)'$/, async f
 });
 
 Then(/^.* can not see deleted teacher with name '([^']*)' on the list of teachers$/, async function (teacherName) {
-	return editCopyCoursePage.checkThatTeacherIsVisible(teacherName, false)
+	return editCopyCoursePage.isTeacherVisible(teacherName, false);
 });

--- a/step_definitions/management_teachers/deleteTeacher_steps.js
+++ b/step_definitions/management_teachers/deleteTeacher_steps.js
@@ -1,1 +1,27 @@
 'use strict';
+
+const navigationLeftPanel = require('../../page-objects/pages/NavigationLeftPage');
+const manageCourses = require('../../page-objects/pages/managementPages/ManageCoursesPage');
+const editCopyCoursePage = require('../../page-objects/pages/coursePages/CRSSEditCopyCoursePage');
+
+//WHEN
+When(/^.* goes to course management$/, function () {
+	return navigationLeftPanel.clickNavItemManageCourses();
+});
+
+When(/^.* adds another teacher with '([^']*)' to course$/, async function (teacherUsername) {
+	await manageCourses.setTeacher(teacherUsername);
+});
+
+When(/^.* clicks Edit-course with '([^']*)' button$/, async function (courseName) {
+	await manageCourses.clickEditCourseByNameBtn(courseName);
+});
+
+//THEN
+Then(/^.* course with '([^']*)' has two teachers with names '([^']*)'$/, async function (courseName, teacherNames) {
+	return manageCourses.areTeacherNamesVisible(courseName, teacherNames);
+});
+
+Then(/^.* can not see deleted teacher with name '([^']*)' on the list of teachers$/, async function (teacherName) {
+	return editCopyCoursePage.checkThatTeacherIsVisible(teacherName, false)
+});


### PR DESCRIPTION
# Description
- added two new scenarios for deletion concept
- scenario that checks if deleted student can't be seen anymore in the course
- scenario that checks if deleted teacher can't be seen anymore in the course

## Links to Tickets or other pull requests
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/260
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-7901

## Changes
- a new scenario was added inside the feature file deleteStudent.feature
- a new scenario was added inside the feature file deleteTeacher.feature

## Deployment
nn

## New Repos, NPM pakages or vendor scripts
nn

## Approval for review
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=92831762)