### PR TITLE
 SC-7126 - create a class with schoolYear due to bugfix on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Added
 
+- SC-7126 - Fix test of createClass due to bugfix on client
 - SC-6814 - Delete class test
 - SC-5795 - CreateUser and send registration link
 - SC-7736 - Deleted User forgot password functionality

--- a/features/management_classes/createClass.feature
+++ b/features/management_classes/createClass.feature
@@ -20,11 +20,11 @@ Feature: Set of tests to create classes
         Given <userRole> logs in with email '<username>' and password '<password>'
         And <userRole> goes to management
         And <userRole> goes to class management
-        When <userRole> creates class with custom name '<customClassName>'
+        When <userRole> creates class with custom name '<customClassName>' and '<schoolYear>'
         And <userRole> adds a group of '<numberOfStudentsInClass>' students with firstname '<studentsFirstname>' and lastname '<studentLastname>' to the class
         And <userRole> clicks on Save-changes in class button
         Then <userRole> should see that number of students in class with name '<customClassName>' is '<numberOfStudentsInClass>'
         Examples:
-            | userRole | username                  		 | password       | customClassName | numberOfStudentsInClass | studentsFirstname | studentLastname |
-			| teacher  | karl.teacher.qa@schul-cloud.org | Schulcloud1qa! | 1C    	        | 3                       | Student           | LastName        |
+            | userRole | username                  		 | password       | customClassName | numberOfStudentsInClass | studentsFirstname | studentLastname | schoolYear |
+			| teacher  | karl.teacher.qa@schul-cloud.org | Schulcloud1qa! | 1C    	        | 3                       | Student           | LastName        | 2020/21	 |
 

--- a/features/management_classes/createClass.feature
+++ b/features/management_classes/createClass.feature
@@ -9,11 +9,11 @@ Feature: Set of tests to create classes
         Given <userRole> logs in with email '<username>' and password '<password>'
         And <userRole> goes to management
         And <userRole> goes to class management
-        When <userRole> creates class with custom name '<customClassName>'
+        When <userRole> creates class with custom name '<customClassName>' and '<schoolYear>'
         Then <userRole> should see that class with name '<customClassName>' and '0' members is visible
         Examples:
-            | userRole | username                         | password       | customClassName |
-            | admin    | olivier.admin.qa@schul-cloud.org | Schulcloud1qa! | 11c             |
+            | userRole | username                         | password       | customClassName | schoolYear |
+            | admin    | olivier.admin.qa@schul-cloud.org | Schulcloud1qa! | 11c             | 2020/21	  |
 
     @createClassWith3Members
     Scenario Outline: As a user, I want to be able to create class without any members

--- a/features/management_classes/editClass.feature
+++ b/features/management_classes/editClass.feature
@@ -9,13 +9,13 @@ Feature: I want to edit a class
 		When <userRole> logs in
 		And <userRole> goes to management
 		And <userRole> goes to class management
-		When <userRole> creates class with custom name '<customClassName>'
+		When <userRole> creates class with custom name '<customClassName>' and '<schoolYearOld>'
 		And <userRole> edits custom class name to '<newCustomClassName>' and class school year to '<schoolYear>'
 		And <userRole> opens classes tab with name '<schoolYear>'
 		Then <userRole> should see that class with name '<newCustomClassName>' and teacher lastname '<teacherLastname>' is visible
 		Examples:
-			| userRole | customClassName | newCustomClassName | schoolYear | teacherLastname |
-			| teacher  | 8a              | 4d                 | 2021/22    | Herzog          |
+			| userRole | customClassName | newCustomClassName | schoolYear | teacherLastname | schoolYearOld |
+			| teacher  | 8a              | 4d                 | 2021/22    | Herzog          | 2020/21 		 |
 
 	@editClassAddStudentTeacherAndDeleteStudentTeacher
 	Scenario Outline: As a user, I want to be able to edit a class

--- a/step_definitions/management_classes/createClass_steps.js
+++ b/step_definitions/management_classes/createClass_steps.js
@@ -15,6 +15,10 @@ When(/^.* creates class with custom name '([^']*)'$/, async function (customClas
 	await manageClass.createNewClass({customClassName: customClassName});
 });
 
+When(/^.* creates class with custom name '([^']*)' and '([^']*)'$/, async function (customClassName, schoolYear) {
+	await manageClass.createNewClass({customClassName: customClassName, schoolYear: schoolYear});
+});
+
 When(/^.* creates a class with grade '([^']*)' and name '([^']*)'$/, async function (className, classGrade) {
 	await manageClass.createNewClass({className: className, classGrade: classGrade});
 });


### PR DESCRIPTION
# Description
created because of changes in https://github.com/hpi-schul-cloud/schulcloud-client/pull/2406/

## Links to Tickets or other pull requests

- https://github.com/hpi-schul-cloud/schulcloud-client/pull/2406/
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-7126

## Changes
added create class with a schoolYear