### PR TITLE
update e2e testcases: new way to switch to user language

### DIFF
--- a/features/tasks/copyTask.feature
+++ b/features/tasks/copyTask.feature
@@ -4,7 +4,7 @@ Feature: Set of tests to copy tasks
 	Background: User opens Schul-cloud homepage Website
 		Given user arrives on the Schul-Cloud homepage
 
-	@copySimpleTask @e2eCore @tasks_and_other @unstableTest
+	@copySimpleTask @e2eCore @unstableTest
 	Scenario Outline: As a user, I want to be able to log in and copy an existing task
 		When <userRole> logs in
 		And <userRole> goes to tasks page

--- a/features/tasks/deleteTask.feature
+++ b/features/tasks/deleteTask.feature
@@ -4,7 +4,7 @@ Feature: Set of tests to delete tasks
 	Background: User opens Schul-cloud homepage Website
 		Given user arrives on the Schul-Cloud homepage
 
-	@deleteSimpleTask @e2eCore @tasks_and_other @unstableTest
+	@deleteSimpleTask @e2eCore @unstableTest
 	Scenario Outline: As a user, I want to be able to log in and delete an existing task
 		When <userRole> logs in
 		And <userRole> goes to tasks page

--- a/page-objects/pages/AccountPage.js
+++ b/page-objects/pages/AccountPage.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const chromeDriver = require("../../runtime/chromeDriver.js");
-const { click } = require("../../runtime/helpers/elementHelpers.js");
 const elementHelpers = require("../../runtime/helpers/elementHelpers.js");
 const waitHelpers = require("../../runtime/helpers/waitHelpers.js");
 const LoginPage = require("./generalPagesBeforeLogin/LoginPage.js");
@@ -18,7 +16,7 @@ const languageMenu = {
 	ukrainian: "//a[@data-testid = 'available-language-ua']",
 };
 
-/*function getLanguageSelector(language) {
+function getLanguageSelector(language) {
 	let languageSel = "";
 	const action = language.toLowerCase();
 	switch (action) {
@@ -39,7 +37,7 @@ const languageMenu = {
 			break;
 	}
 	return languageSel;
-}*/
+}
 
 async function clickSubmitAccountDataBtn() {
     await elementHelpers.clickAndWait(submitAccountDataBtn);
@@ -59,19 +57,8 @@ async function setNewPasswordConfirmation(newPassword = LoginPage.defaultNewPass
 
 async function selectLanguage(language) {
     await elementHelpers.clickAndWait(languageMenu.german);
-    if (language === 'English') {
-        await elementHelpers.clickAndWait(languageMenu.english);
-        await driver.pause(500);
-    } else if (language === 'Spanish'){
-        await elementHelpers.clickAndWait(languageMenu.spanish);
-        await driver.pause(500);
-    } else if (language === 'Ukrainian'){
-        await elementHelpers.clickAndWait(languageMenu.ukrainian);
-        await driver.pause(500);
-    } else {
-        await elementHelpers.clickAndWait(languageMenu.german);
-        await driver.pause(500);
-    }
+	await elementHelpers.clickAndWait(getLanguageSelector (language));
+	await driver.pause(500);
 }
 
 async function changePassword(oldPassword, newPassword) {

--- a/page-objects/pages/TASKListPage.js
+++ b/page-objects/pages/TASKListPage.js
@@ -134,7 +134,7 @@ async function clickAtTask(taskName) {
 				clickOnThatTask = await getTaskFromTaskOverview(taskName);
 				if (typeof clickOnThatTask === 'object') {
 					isTaskClickable = true;
-					await elementHelpers.clickAndWait(clickOnThatTask);
+					await driver.execute(`arguments[0].click()`, clickOnThatTask);
 				}
 			}
 		} else if (typeof clickOnThatTask != 'object') {
@@ -142,10 +142,10 @@ async function clickAtTask(taskName) {
 			await waitHelpers.waitUntilElementIsClickable(clickOnThatTask);
 			clickOnThatTask = await getTaskFromTaskOverview(taskName);
 			if (typeof clickOnThatTask === 'object') {
-				await elementHelpers.clickAndWait(clickOnThatTask);
+				await driver.execute(`arguments[0].click()`, clickOnThatTask);
 			}
 		} else {
-			await elementHelpers.clickAndWait(clickOnThatTask);
+			await driver.execute(`arguments[0].click()`, clickOnThatTask);
 		}
 	} catch (error) {
 		const msg = error.message;
@@ -194,7 +194,7 @@ async function hoverOverTaskAndClickMenu(taskName) {
 	let taskActionMenuOption = await driver.$(mod_extsprintf.sprintf(taskActionMenu, taskName));
 	await elementHelpers.moveToElement(taskTitle);
 	await waitHelpers.waitUntilElementIsClickable(taskTitle);
-	await elementHelpers.click(taskActionMenuOption);
+	await driver.execute(`arguments[0].click()`, taskActionMenuOption);
 }
 
 async function isTaskGraded(taskName) {

--- a/runtime/helpers/APIhelpers.js
+++ b/runtime/helpers/APIhelpers.js
@@ -62,11 +62,12 @@ const Axios = require('axios');
 	async function getUserInfo (attribute) {
 		const cookie = await driver.getCookies(['jwt']);
 		const jwt = cookie[0].value;
+		console.log(jwt);
 		const info = await Axios.request({
 			url: `${SERVER.URL}/me`,
 			method: 'get',
 			headers: {
-				Authorization: `${jwt}`,
+				Authorization: `Bearer ${jwt}`,
 			},
 		});
 		let object = info.data;

--- a/runtime/helpers/APIhelpers.js
+++ b/runtime/helpers/APIhelpers.js
@@ -62,7 +62,6 @@ const Axios = require('axios');
 	async function getUserInfo (attribute) {
 		const cookie = await driver.getCookies(['jwt']);
 		const jwt = cookie[0].value;
-		console.log(jwt);
 		const info = await Axios.request({
 			url: `${SERVER.URL}/me`,
 			method: 'get',


### PR DESCRIPTION
# Description
Update the e2e framework after the user language selection process has been changed

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-1583

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=92831762)
