### PR TITLE
BC-1386: Missing active state on Courses

### DIFF
--- a/features/user_settings/changeLanguageMenu.feature
+++ b/features/user_settings/changeLanguageMenu.feature
@@ -13,12 +13,12 @@ Feature: Test set for user settings
         Then <userRole> should see that all menu items are visible: '<menuItems>'
 Examples:
         | userRole  | username                          | password       | language  | menuItems                                                                                                                    |
-        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | English   | DASHBOARD,,COURSES,TEAMS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,MANAGEMENT,HELP SECTION                               |
-        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | English   | DASHBOARD,,COURSES,TEAMS,TASKS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,MANAGEMENT,HELP SECTION                         |
-        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | English   | DASHBOARD,,COURSES,TEAMS,TASKS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,HELP SECTION                                    |
-        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | Spanish   | PANEL,,CURSOS,EQUIPOS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,ADMINISTRACIÓN,SECCIÓN DE AYUDA               |
-        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | Spanish   | PANEL,,CURSOS,EQUIPOS,TAREAS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,ADMINISTRACIÓN,SECCIÓN DE AYUDA        |
-        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | Spanish   | PANEL,,CURSOS,EQUIPOS,TAREAS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,SECCIÓN DE AYUDA                       |
-        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,,КУРСИ,КОМАНДИ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,КЕРУВАННЯ,ДОВІДКОВИЙ РОЗДІЛ          |
-        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,,КУРСИ,КОМАНДИ,ЗАВДАННЯ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,КЕРУВАННЯ,ДОВІДКОВИЙ РОЗДІЛ |
-        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,,КУРСИ,КОМАНДИ,ЗАВДАННЯ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,ДОВІДКОВИЙ РОЗДІЛ           |
+        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | English   | DASHBOARD,COURSES,TEAMS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,MANAGEMENT,HELP SECTION                               |
+        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | English   | DASHBOARD,COURSES,TEAMS,TASKS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,MANAGEMENT,HELP SECTION                         |
+        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | English   | DASHBOARD,COURSES,TEAMS,TASKS,MY FILES,NEWS,CALENDAR,LEARNING STORE,ADD-ONS,HELP SECTION                                    |
+        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | Spanish   | PANEL,CURSOS,EQUIPOS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,ADMINISTRACIÓN,SECCIÓN DE AYUDA               |
+        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | Spanish   | PANEL,CURSOS,EQUIPOS,TAREAS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,ADMINISTRACIÓN,SECCIÓN DE AYUDA        |
+        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | Spanish   | PANEL,CURSOS,EQUIPOS,TAREAS,MIS ARCHIVOS,NOTICIAS,CALENDARIO,LERN-STORE,COMPLEMENTOS,SECCIÓN DE AYUDA                       |
+        | admin     | olivier.admin.qa@schul-cloud.org  | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,КУРСИ,КОМАНДИ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,КЕРУВАННЯ,ДОВІДКОВИЙ РОЗДІЛ          |
+        | teacher   | dmitri.teacher.qa@schul-cloud.org | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,КУРСИ,КОМАНДИ,ЗАВДАННЯ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,КЕРУВАННЯ,ДОВІДКОВИЙ РОЗДІЛ |
+        | student   | ole.bart.qa@schul-cloud.org       | Schulcloud1qa! | Ukrainian | ПАНЕЛЬ КЕРУВАННЯ,КУРСИ,КОМАНДИ,ЗАВДАННЯ,МОЇ ФАЙЛИ,НОВИНИ,КАЛЕНДАР,НАВЧАЛЬНИЙ МАГАЗИН,ДОПОВНЕННЯ,ДОВІДКОВИЙ РОЗДІЛ           |


### PR DESCRIPTION
# Description
Removing double course sidebar items and fixing the active state for sidebar item "courses", so the tests had to be adjusted

## Links to Tickets or other pull requests
Ticket: https://ticketsystem.dbildungscloud.de/browse/BC-1386
Legacy Client: https://github.com/hpi-schul-cloud/schulcloud-client/pull/2838
Server: https://github.com/hpi-schul-cloud/schulcloud-server/pull/3427
Nuxt-Client: https://github.com/hpi-schul-cloud/nuxt-client/pull/2144
https://github.com/hpi-schul-cloud/dof_app_deploy/pull/234

## Changes

## Deployment

## New Repos, NPM packages or vendor scripts

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=92831762)
