### PR TITLE
BRB-4 change teachername and teachernames in deleteTeacher.feature

### DIFF
--- a/features/management_teachers/deleteTeacher.feature
+++ b/features/management_teachers/deleteTeacher.feature
@@ -53,7 +53,7 @@ Feature: Set of tests to delete teachers
 		Then <checkUserRole> can not see deleted teacher with name '<teacherName>' on the list of teachers
 		Examples:
 			| userRole | adminUsername                | adminPassword  | courseName                    | teacherName | teacherNames  | teacherMailAddress              | checkUserRole | teacherUsername                 |
-			| admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | Course with subject and tasks | Lara Hande  | Herzog, Hande | lara.teacher.qa@schul-cloud.org | teacher       | karl.teacher.qa@schul-cloud.org |
+			| admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | Course with subject and tasks | Hande, Lara  | Hande, Herzog | lara.teacher.qa@schul-cloud.org | teacher       | karl.teacher.qa@schul-cloud.org |
 
 	@deletedTeacherIsNotVisibleInClass @deletionConcept
 	Scenario Outline: As a user, I want to delete a teacher from a class and he will be no longer visible as class teacher
@@ -70,4 +70,3 @@ Feature: Set of tests to delete teachers
 		Examples:
 			| userRole | adminUsername                | password       | teacherUsername                 | className |
 			| admin    | kai.admin.qa@schul-cloud.org | Schulcloud1qa! | karl.teacher.qa@schul-cloud.org | 9a        |
-	


### PR DESCRIPTION
# Description
In order to make the deployment for the 'schulcloud-client: BRB-4_last_name_sorting'-branch working, I change the order of the teacher names for the tests.

## Links to Tickets or other pull requests
Pull request on schulcloud-client: https://github.com/hpi-schul-cloud/schulcloud-client/pull/2815

## Changes
Change the teacher name sorting in schulcloud-client, so that I adapt the teacher name sorting in the test from 'Lara Hande' to 'Hande, Lara' and 'Herzog, Hande' to 'Hande, Herzog'.

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=92831762)
